### PR TITLE
Update Software versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     container:
-      image: ghcr.io/foamscience/openfoam-smartsim:cpu
+      image: ghcr.io/foamscience/openfoam-smartsim:cpu-2312
       options: --user openfoam
       env:
         CATCH_TIMEOUT: 20
@@ -46,13 +46,13 @@ jobs:
 
       - name: Compile
         run: |
-          source /usr/lib/openfoam/openfoam2212/etc/bashrc
+          source /usr/lib/openfoam/openfoam2312/etc/bashrc
           mkdir -p $FOAM_USER_LIBBIN
           source SOURCEME.sh
 
       - name: Compile Tests and Run
         run: |
-          source /usr/lib/openfoam/openfoam2212/etc/bashrc
+          source /usr/lib/openfoam/openfoam2312/etc/bashrc
           source SOURCEME.sh
           export SSDB="redis:6379"
           git clone https://github.com/FoamScience/foamUT $FOAM_FOAMUT

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ The source code license: GPL-3.0-or-later
 
 ## Requirements
 
-1. [OpenFOAM-v2212] or newer, or a recent [development version][OpenFOAM-git]
+1. [OpenFOAM-v2312] or newer, or a recent [development version][OpenFOAM-git]
    from [OpenFOAM.com][OpenFOAM]. 
-2. [SmartSim] 0.5.1 
+2. [SmartSim] 0.6.0 
 2. [SmartRedis] N.N.N 
 
 ## Building
@@ -52,7 +52,7 @@ source SOURCEME.sh
 ----
 
 [OpenFOAM]: https://www.openfoam.com
-[OpenFOAM-v2212]: https://www.openfoam.com/releases/openfoam-v2212/
+[OpenFOAM-v2312]: https://www.openfoam.com/releases/openfoam-v2312/
 [OpenFOAM-git]: https://develop.openfoam.com/Development/openfoam
 
 [SmartSim]: https://github.com/CrayLabs/SmartSim 

--- a/src/smartRedis/smartRedisClient/smartRedisClient.C
+++ b/src/smartRedis/smartRedisClient/smartRedisClient.C
@@ -136,9 +136,6 @@ Foam::smartRedisClient::postMetadata()
         }
         redisDB_->client().put_dataset(ds);
     }
-    // @todo Relying on Jinja2 for templating
-    // @body Maybe this is the best course of action for c/fortran clients
-    //       wanting to interact with this class
     Info<< "The following Jinja2 templates define the naming convention:"
         << meta << endl;
     return meta;

--- a/src/smartRedis/smartRedisClient/smartRedisClient.H
+++ b/src/smartRedis/smartRedisClient/smartRedisClient.H
@@ -235,8 +235,6 @@ public:
         );
 
         //- Send a set of OpenFOAM fields of any type as SmartRedis tensors
-        // @todo const-functions should also be enforced on the SmartRedis API
-        // @body This is the best example for a `void sendFields(const wordList& fieldNames) const;`
         void sendGeometricFields
         (
             const wordList& fieldNames,

--- a/src/smartRedis/smartRedisClient/smartRedisClientTemplates.C
+++ b/src/smartRedis/smartRedisClient/smartRedisClientTemplates.C
@@ -83,11 +83,6 @@ void smartRedisClient::packFields
     }
 }
 
-//@todo: reading patch values from DB might not make send 
-//@body: while sending face patch values to DB makes perfect sense,
-//       reading them back from DB may not be the best idea. This is implemented
-//       to follow the design pattern, and because the boundary is actually 
-//       exposed by a mutable reference
 template<class T>
 void smartRedisClient::getFields
 (

--- a/tutorials/meshMotion/spinningDisk/0.orig/pointDisplacement
+++ b/tutorials/meshMotion/spinningDisk/0.orig/pointDisplacement
@@ -36,8 +36,6 @@ boundaryField
     {
         type        solidBodyMotionDisplacement;
         solidBodyMotionFunction  multiMotion;
-        // @todo: check displacement configuration
-        // @body: had to set `multiMotionCoeffs.solidBodyMotionFunction` to `linearMotion` for things to work
         multiMotionCoeffs
         {
             solidBodyMotionFunction  linearMotion;

--- a/tutorials/postProcessing/foamSmartSimSvd/cavity/Allrun
+++ b/tutorials/postProcessing/foamSmartSimSvd/cavity/Allrun
@@ -1,0 +1,14 @@
+#!/bin/sh
+cd "${0%/*}" || exit                                # Run from this directory
+. ${WM_PROJECT_DIR:?}/bin/tools/RunFunctions        # Tutorial run functions
+#------------------------------------------------------------------------------
+
+restore0Dir
+
+runApplication blockMesh
+
+runApplication decomposePar
+
+runParallel $(getApplication) 
+
+#------------------------------------------------------------------------------


### PR DESCRIPTION
- Bump OpenFOAM CI version to v2312 (Patched for Gcc11)
- Bump SmartSim CI version to 0.6.0
- SmartRedis always gets built from the develop branch when `SOURCEME.sh` is sourced
- Adds a `Allrun` for the `foamSmartSimSvd/cavity` case